### PR TITLE
Fix PHP 8.2+ Deprecated message

### DIFF
--- a/individual-author.php
+++ b/individual-author.php
@@ -40,6 +40,20 @@ if ( ! class_exists( 'Ima_Class', false ) && is_multisite() ) {
 	class Ima_Class {
 
 		/**
+		 * Stores the display name field name for the current site.
+		 *
+		 * @var string
+		 */
+		public $display_name_field_name;
+
+		/**
+		 * Stores the discription field name for the current site.
+		 *
+		 * @var string
+		 */
+		public $description_field_name;
+
+		/**
 		 * initialize the plugin
 		 * @since 1.0
 		 */


### PR DESCRIPTION
Using PHP 8.2, the plugin produces the following deprecation messages:
```
PHP Deprecated:  Creation of dynamic property Ima_Class::$display_name_field_name is deprecated in .../individual-multisite-author/individual-author.php on line 56
PHP Deprecated:  Creation of dynamic property Ima_Class::$description_field_name is deprecated in .../individual-multisite-author/individual-author.php on line 57
```